### PR TITLE
Fix version typo

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-libxfont1 (1.5.2-5) UNRELEASED; urgency=medium
+libxfont1 (1:1.5.2-5) UNRELEASED; urgency=medium
 
   * Added conflict with libxfont-dev
 


### PR DESCRIPTION
The incorrect version was breaking the install of the xorg packages